### PR TITLE
Adapt WebApi to latest changes in the registry

### DIFF
--- a/src/main/scala/de/upb/cs/swt/delphi/instancemanagement/Instance.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instancemanagement/Instance.scala
@@ -54,7 +54,7 @@ trait JsonSupport extends SprayJsonSupport with DefaultJsonProtocol {
     }
   }
 
-  implicit val instanceFormat : JsonFormat[Instance] = jsonFormat7(Instance)
+  implicit val instanceFormat : JsonFormat[Instance] = jsonFormat8(Instance)
 }
 
 final case class Instance (
@@ -64,7 +64,8 @@ final case class Instance (
                             name: String,
                             componentType: InstanceEnums.ComponentType,
                             dockerId: Option[String],
-                            instanceState: InstanceEnums.State
+                            instanceState: InstanceEnums.State,
+                            labels: List[String]
                           )
 object InstanceEnums {
   type ComponentType = ComponentType.Value

--- a/src/main/scala/de/upb/cs/swt/delphi/instancemanagement/InstanceRegistry.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/instancemanagement/InstanceRegistry.scala
@@ -253,7 +253,7 @@ object InstanceRegistry extends JsonSupport with AppLogging
 
   private def createInstance(id: Option[Long], controlPort : Int, name : String) : Instance =
     Instance(id, InetAddress.getLocalHost.getHostAddress,
-      controlPort, name, ComponentType.WebApi, None, InstanceState.Running)
+      controlPort, name, ComponentType.WebApi, None, InstanceState.Running, List.empty[String])
 
   def reportStart(id: String, configuration: Configuration):Try[ResponseEntity] ={
     val request = HttpRequest(method = HttpMethods.GET, configuration.instanceRegistryUri + "/reportStart")

--- a/src/main/scala/de/upb/cs/swt/delphi/webapi/Configuration.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/webapi/Configuration.scala
@@ -49,7 +49,8 @@ class Configuration( //Server and Elasticsearch configuration
       "Default ElasticSearch instance",
       ComponentType.ElasticSearch,
       None,
-      InstanceState.Running)
+      InstanceState.Running,
+      List.empty[String])
   }
   val defaultElasticSearchPort: Int = 9200
   val defaultElasticSearchHost: String = "elasticsearch://localhost"


### PR DESCRIPTION
**Reason for this PR**
The API of the Instance Registry has been change [lately](https://github.com/delphi-hub/delphi-registry/pull/33). The goal was to support new UI requirements. The relevant changes are:
- */matchingInstance* and */matchingResult* now require an additional parameter containing the caller-Id
- The *Instance* now has a new attribute called *labels* of type List[String]

This PR adapts the WebApi to support the new API version. The same has been done for the crawler [here](https://github.com/delphi-hub/delphi-crawler/pull/30).

**Changes**
- Added attribute *labels: List[String]* to case class *Instance*
- Changed calls to */matchingInstance* and */matchingResult* to post the parameter *callerId* as well