### PR TITLE
Improved Error Messages on Client-Side Errors

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "delphi-webapi"
 
-version := "0.9.5.1"
+version := "0.9.6-SNAPSHOT"
 
 scalaVersion := "2.13.1"
 

--- a/src/main/scala/de/upb/cs/swt/delphi/webapi/DelphiRoutes.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/webapi/DelphiRoutes.scala
@@ -29,7 +29,7 @@ import de.upb.cs.swt.delphi.webapi.FeatureJson._
 import de.upb.cs.swt.delphi.webapi.IpLogActor._
 import de.upb.cs.swt.delphi.webapi.StatisticsJson._
 import de.upb.cs.swt.delphi.webapi.search.QueryRequestJson._
-import de.upb.cs.swt.delphi.webapi.search.{QueryRequest, SearchError, SearchQuery}
+import de.upb.cs.swt.delphi.webapi.search.{InvalidQueryError, QueryRequest, SearchError, SearchQuery}
 import spray.json._
 
 import scala.concurrent.duration._
@@ -112,6 +112,9 @@ class DelphiRoutes(requestLimiter: RequestLimitScheduler) extends JsonSupport wi
               e match {
                 case se: SearchError => {
                   HttpResponse(StatusCodes.ServerError(StatusCodes.InternalServerError.intValue)(se.toJson.toString(), ""))
+                }
+                case iqe: InvalidQueryError => {
+                  HttpResponse(StatusCodes.ClientError(StatusCodes.BadRequest.intValue)(iqe.toJson.toString(), ""))
                 }
                 case _ => {
                   HttpResponse(StatusCodes.ServerError(StatusCodes.InternalServerError.intValue)("Search query failed", ""))

--- a/src/main/scala/de/upb/cs/swt/delphi/webapi/search/SearchQuery.scala
+++ b/src/main/scala/de/upb/cs/swt/delphi/webapi/search/SearchQuery.scala
@@ -31,6 +31,7 @@ import scala.io.{Codec, Source}
 import scala.util.{Failure, Success, Try}
 import spray.json._
 import de.upb.cs.swt.delphi.webapi.FeatureJson._
+import org.parboiled2.{ParseError, Position}
 
 
 class SearchQuery(configuration: Configuration, featureExtractor: FeatureQuery) {
@@ -52,7 +53,7 @@ class SearchQuery(configuration: Configuration, featureExtractor: FeatureQuery) 
     val publicFieldNames = internalFeatures.map(i => i.name)
     val invalidFields = fields.toSet.filter(f => !publicFieldNames.contains(f))
 
-    if (invalidFields.size > 0) return Failure(new IllegalArgumentException(s"Unknown field name(s) used. (${invalidFields.mkString(",")})"))
+    if (invalidFields.size > 0) return Failure(new InvalidQueryFieldsError(parsedQuery.toString, invalidFields))
 
     val translatedFields = fields.toSet.map(externalToInternalFeature(_))
     def getPrefix (in: String) : String = {
@@ -80,7 +81,7 @@ class SearchQuery(configuration: Configuration, featureExtractor: FeatureQuery) 
 
     response match {
       case RequestSuccess(_, body, _, result) => Success(result.hits)
-      case r => Failure(new IllegalArgumentException(r.toString))
+      case r => Failure(new SearchError(f"Failed to query database: ${r.toString}"))
     }
   }
 
@@ -166,8 +167,12 @@ class SearchQuery(configuration: Configuration, featureExtractor: FeatureQuery) 
     val validSize = size.exists(query.limit.getOrElse(defaultFetchSize) <= _)
     if (validSize) {
       val parserResult = new Syntax(query.query).QueryRule.run()
+
       parserResult match {
-        case Failure(e) => Failure(e)
+        case Failure(ParseError(Position(_, line, column), _, _)) =>
+          Failure(new InvalidQueryError(f"Syntax error in query (near line $line, colum $column)", query.query))
+        case Failure(e) =>
+          Failure(e)
         case Success(parsedQuery) => {
           checkAndExecuteParsedQuery(parsedQuery, query.limit.getOrElse(defaultFetchSize)) match {
             case Failure(e) => Failure(e)
@@ -177,7 +182,8 @@ class SearchQuery(configuration: Configuration, featureExtractor: FeatureQuery) 
       }
     }
     else {
-      val errorMsg = new SearchError(s"Query limit exceeded default limit:  ${query.limit}>${size}")
+      val errorMsg = new InvalidQueryError(
+        s"Query limit exceeded default limit:  ${query.limit.getOrElse(defaultFetchSize)} > ${size.getOrElse("None")}", query.query)
       Failure(errorMsg)
     }
   }


### PR DESCRIPTION
**Reason for this PR**
As reported in #34, the error messages returned by the webapi in cases of invalid queries / invalid query limits / errors during database interaction have all been 500 Internal Server Errors, and even exposed some application internals. 
This implies that regular users may not understand the cause for a query failure, and malicious users may learn something about private data.

**Changes in this PR**
Introduced distinct HttpResonses on different errors:
* If the execution of an ElasticSearch query fails due to an unknown reason, a ```500 Internal Server Error``` will be returned. The StatusDescription will contain a JSON object holding a ```msg``` ("Database Communication Failed") and a ```query``` field, the latter holding the original query that triggered the error.
* If the maximum query limit (10000) is exceeded by the client, then a ```400 Bad Request``` is returned. The StatusDescription also holds the aforementioned JSON object, with the ```msg``` stating that the limit has been exceeded, including the value of the limit.
* If the query could not be parsed, a ```400 Bad Request``` is returned. The StatusDescription also holds the aforementioned JSON object, with the ```msg``` explaining that there was a syntax error in the query, including the line and column of the error.
* If the query Syntax was valid but contained unknown field names, a ```400 Bad Request``` is returned. The StatusDescription also holds the aforementioned JSON object. The ```msg``` states that there were unknown field names, and an additional attribute ```invalid_fields``` holds an array of all invalid field names.
* All other (unexpected) errors will results in a ```500 Internal Server Error```

**Additional Context**
A upcoming PR for the delphi-cli will introduce support for the ```400 Bad Request``` responses, which will then print the error messages in order to explain search errors to the user. **EDIT:** PR is at https://github.com/delphi-hub/delphi-cli/pull/46

**Issues**
* Partially addresses #34 